### PR TITLE
FreeBSD support

### DIFF
--- a/taptun.go
+++ b/taptun.go
@@ -32,6 +32,13 @@ func (t *Tun) String() string {
 	return t.name
 }
 
+func (t *Tun) Close() error {
+	if err := t.ReadWriteCloser.Close(); err != nil {
+		return err
+	}
+	return destroyInterface(t.name)
+}
+
 // OpenTap creates a tapN interface and returns a *Tap device connected to
 // the t pinterface.
 func OpenTap() (*Tap, error) {
@@ -50,6 +57,13 @@ type Tap struct {
 
 func (t *Tap) String() string {
 	return t.name
+}
+
+func (t *Tap) Close() error {
+	if err := t.ReadWriteCloser.Close(); err != nil {
+		return err
+	}
+	return destroyInterface(t.name)
 }
 
 // ErrTruncated indicates the buffer supplied to ReadFrame was insufficient

--- a/taptun_freebsd.go
+++ b/taptun_freebsd.go
@@ -6,20 +6,9 @@ import (
 	"unsafe"
 )
 
-const (
-	FIODGNAME     = 0x80106678
-	SIOCIFDESTROY = 0x80206979
-)
-
 type ifreq struct {
 	name [syscall.IFNAMSIZ]byte
 	_    [16]byte
-}
-
-type fiodgnameArg struct {
-	length int32
-	_pad   [4]byte
-	buf    unsafe.Pointer
 }
 
 func interfaceName(fd uintptr) (string, error) {

--- a/taptun_freebsd.go
+++ b/taptun_freebsd.go
@@ -1,0 +1,56 @@
+package taptun
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	FIODGNAME = 0x80106678
+)
+
+type ifreq struct {
+	name [syscall.IFNAMSIZ]byte
+	_    [16]byte
+}
+
+type fiodgnameArg struct {
+	length int32
+	_pad   [4]byte
+	buf    unsafe.Pointer
+}
+
+func interfaceName(fd uintptr) (string, error) {
+	var name [syscall.IFNAMSIZ]byte
+
+	arg := fiodgnameArg{length: syscall.IFNAMSIZ, buf: unsafe.Pointer(&name)}
+	if err := ioctl(fd, FIODGNAME, unsafe.Pointer(&arg)); err != nil {
+		return "", err
+	}
+	return cstringToGoString(name[:]), nil
+}
+
+func createInterface(clonefile string) (string, *os.File, error) {
+	f, err := os.OpenFile(clonefile, os.O_RDWR, 0600)
+	if err != nil {
+		return "", nil, err
+	}
+
+	fd := f.Fd()
+	ifname, err := interfaceName(fd)
+	if err != nil {
+		f.Close()
+		return "", nil, err
+	}
+
+	return ifname, f, nil
+}
+
+func openTun() (string, *os.File, error) {
+	return createInterface("/dev/tun")
+}
+
+func openTap() (string, *os.File, error) {
+	return createInterface("/dev/tap")
+}

--- a/taptun_freebsd.go
+++ b/taptun_freebsd.go
@@ -47,7 +47,7 @@ func destroyInterface(name string) error {
 	ifreq := ifreq{}
 	copy(ifreq.name[:], []byte(name))
 
-	return ioctl(uintptr(s), SIOCIFDESTROY, unsafe.Pointer(&ifreq))
+	return ioctl(uintptr(s), syscall.SIOCIFDESTROY, unsafe.Pointer(&ifreq))
 }
 
 func openTun() (string, *os.File, error) {

--- a/taptun_freebsd.go
+++ b/taptun_freebsd.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	FIODGNAME = 0x80106678
+	FIODGNAME     = 0x80106678
+	SIOCIFDESTROY = 0x80206979
 )
 
 type ifreq struct {
@@ -45,6 +46,19 @@ func createInterface(clonefile string) (string, *os.File, error) {
 	}
 
 	return ifname, f, nil
+}
+
+func destroyInterface(name string) error {
+	s, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(s)
+
+	ifreq := ifreq{}
+	copy(ifreq.name[:], []byte(name))
+
+	return ioctl(uintptr(s), SIOCIFDESTROY, unsafe.Pointer(&ifreq))
 }
 
 func openTun() (string, *os.File, error) {

--- a/taptun_freebsd_386.go
+++ b/taptun_freebsd_386.go
@@ -6,7 +6,6 @@ import (
 
 const (
 	FIODGNAME     = 0x80086678
-	SIOCIFDESTROY = 0x80206979
 )
 
 type fiodgnameArg struct {

--- a/taptun_freebsd_386.go
+++ b/taptun_freebsd_386.go
@@ -1,0 +1,15 @@
+package taptun
+
+import (
+	"unsafe"
+)
+
+const (
+	FIODGNAME     = 0x80086678
+	SIOCIFDESTROY = 0x80206979
+)
+
+type fiodgnameArg struct {
+	length int32
+	buf    unsafe.Pointer
+}

--- a/taptun_freebsd_amd64.go
+++ b/taptun_freebsd_amd64.go
@@ -6,7 +6,6 @@ import (
 
 const (
 	FIODGNAME     = 0x80106678
-	SIOCIFDESTROY = 0x80206979
 )
 
 type fiodgnameArg struct {

--- a/taptun_freebsd_amd64.go
+++ b/taptun_freebsd_amd64.go
@@ -1,0 +1,16 @@
+package taptun
+
+import (
+	"unsafe"
+)
+
+const (
+	FIODGNAME     = 0x80106678
+	SIOCIFDESTROY = 0x80206979
+)
+
+type fiodgnameArg struct {
+	length int32
+	_pad   [4]byte
+	buf    unsafe.Pointer
+}

--- a/taptun_linux.go
+++ b/taptun_linux.go
@@ -28,14 +28,10 @@ func createInterface(flags uint16) (string, *os.File, error) {
 	return cstringToGoString(ifr.name[:]), f, nil
 }
 
-func ioctl(fd, request uintptr, argp unsafe.Pointer) error {
-	if _, _, e := syscall.Syscall6(syscall.SYS_IOCTL, fd, request, uintptr(argp), 0, 0, 0); e != 0 {
-		return e
-	}
-	return nil
+func openTun() (string, *os.File, error) {
+	return createInterface(syscall.IFF_TUN | syscall.IFF_NO_PI)
 }
 
-func cstringToGoString(cstring []byte) string {
-	strs := bytes.Split(cstring, []byte{0x00})
-	return string(strs[0])
+func openTap() (string, *os.File, error) {
+	return createInterface(syscall.IFF_TAP | syscall.IFF_NO_PI)
 }

--- a/taptun_linux.go
+++ b/taptun_linux.go
@@ -28,6 +28,10 @@ func createInterface(flags uint16) (string, *os.File, error) {
 	return cstringToGoString(ifr.name[:]), f, nil
 }
 
+func destroyInterface(name string) error {
+	return nil
+}
+
 func openTun() (string, *os.File, error) {
 	return createInterface(syscall.IFF_TUN | syscall.IFF_NO_PI)
 }

--- a/taptun_unsupported.go
+++ b/taptun_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!freebsd
 
 package taptun
 


### PR DESCRIPTION
This adds support for FreeBSD. 

On Linux the interfaces are automatically removed when the fd is closed,
while FreeBSD keeps the interface around. The second commit attempts to
work around this by explicitly destroying the interface on Close() (this is
obviously racy and does not work on panic() etc.)