### PR TITLE
Allow naming of TAP/TUN devices

### DIFF
--- a/taptun.go
+++ b/taptun.go
@@ -12,14 +12,23 @@ import (
 	"unsafe"
 )
 
+// NewTun creates a *Tun device with the specified name and returns the
+// device connected to the tun interface.
+//
+// If an empty string ("") is specified for name, a tunN interface is
+// created.
+func NewTun(name string) (*Tun, error) {
+	n, f, err := openTun(name)
+	return &Tun{
+		ReadWriteCloser: f,
+		name:            n,
+	}, err
+}
+
 // OpenTun creates a tunN interface and returns a *Tun device connected to
 // the tun interface.
 func OpenTun() (*Tun, error) {
-	name, f, err := openTun()
-	return &Tun{
-		ReadWriteCloser: f,
-		name:            name,
-	}, err
+	return NewTun("")
 }
 
 // Tun represents a TUN Virtual Point-to-Point network device.
@@ -39,14 +48,23 @@ func (t *Tun) Close() error {
 	return destroyInterface(t.name)
 }
 
-// OpenTap creates a tapN interface and returns a *Tap device connected to
-// the t pinterface.
-func OpenTap() (*Tap, error) {
-	name, f, err := openTap()
+// NewTap creates a *Tap device with the specified name and returns the
+// device connected to the tap interface.
+//
+// If an empty string ("") is specified for name, a tapN interface is
+// created.
+func NewTap(name string) (*Tap, error) {
+	n, f, err := openTap(name)
 	return &Tap{
 		ReadWriteCloser: f,
-		name:            name,
+		name:            n,
 	}, err
+}
+
+// OpenTap creates a tapN interface and returns a *Tap device connected to
+// the tap interface.
+func OpenTap() (*Tap, error) {
+	return NewTap("")
 }
 
 // Tap represents a TAP Virtual Ethernet network device.

--- a/taptun_linux.go
+++ b/taptun_linux.go
@@ -1,6 +1,7 @@
 package taptun
 
 import (
+	"errors"
 	"os"
 	"syscall"
 	"unsafe"
@@ -12,15 +13,27 @@ type ifreq struct {
 	_pad  [24 - unsafe.Sizeof(uint16(0))]byte
 }
 
-func createInterface(flags uint16) (string, *os.File, error) {
+func createInterface(flags uint16, name string) (string, *os.File, error) {
+	// Last byte of name must be nil for C string, so name must be
+	// short enough to allow that
+	if len(name) > syscall.IFNAMSIZ-1 {
+		return "", nil, errors.New("device name too long")
+	}
+
 	f, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0600)
 	if err != nil {
 		return "", nil, err
 	}
 
+	var nbuf [syscall.IFNAMSIZ]byte
+	copy(nbuf[:], []byte(name))
+
 	fd := f.Fd()
 
-	ifr := ifreq{flags: flags}
+	ifr := ifreq{
+		name:  nbuf,
+		flags: flags,
+	}
 	if err := ioctl(fd, syscall.TUNSETIFF, unsafe.Pointer(&ifr)); err != nil {
 		return "", nil, err
 	}
@@ -31,10 +44,10 @@ func destroyInterface(name string) error {
 	return nil
 }
 
-func openTun() (string, *os.File, error) {
-	return createInterface(syscall.IFF_TUN | syscall.IFF_NO_PI)
+func openTun(name string) (string, *os.File, error) {
+	return createInterface(syscall.IFF_TUN|syscall.IFF_NO_PI, name)
 }
 
-func openTap() (string, *os.File, error) {
-	return createInterface(syscall.IFF_TAP | syscall.IFF_NO_PI)
+func openTap(name string) (string, *os.File, error) {
+	return createInterface(syscall.IFF_TAP|syscall.IFF_NO_PI, name)
 }


### PR DESCRIPTION
Tested working on both linux/amd64 and freebsd/amd64.

Thanks again for your help with the FreeBSD side, @ebfe .

/cc @davecheney @ebfe 